### PR TITLE
Added OPNsense Syslog compatiblity

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # Suricata Alert Extractor
-Just a suricata alert extractor to be used with pfsense log input
+
+A Suricata alert [GROK](https://www.elastic.co/guide/en/logstash/current/plugins-filters-grok.html) extractor to be used with pfsense / OPNsense (Syslog) input.

--- a/suricata-alert-extractor.json
+++ b/suricata-alert-extractor.json
@@ -13,7 +13,22 @@
       },
       "condition_type": "regex",
       "condition_value": "^<.*suricata.*Classification"
+    },
+    {
+      "title": "OPNsense Suricata extractor",
+      "extractor_type": "grok",
+      "converters": [],
+      "order": 0,
+      "cursor_strategy": "copy",
+      "source_field": "message",
+      "target_field": "",
+      "extractor_config": {
+        "grok_pattern": "%{SYSLOGHOST} %{SYSLOGPROG}\\:%{SPACE}\\[%{WORD:action}\\]%{SPACE}\\[%{DATA:suricata_signature_id}\\]%{SPACE}%{DATA:suricata_description}%{SPACE}(\\[Classification: )%{DATA:suricata_classification}\\]%{SPACE}(\\[Priority: )%{INT:suricata_priority}\\]%{SPACE}\\{%{URIPROTO:protocol}\\}%{SPACE}%{IPORHOST:src_host}\\:%{BASE10NUM:src_port}%{SPACE}\\-\\>%{SPACE}%{IPORHOST:dst_host}\\:%{BASE10NUM:dst_port}",
+        "named_captures_only": true
+      },
+      "condition_type": "regex",
+      "condition_value": ".*suricata.*Classification.*->"
     }
   ],
-  "version": "2.2.0-SNAPSHOT"
+  "version": "3.0.2"
 }


### PR DESCRIPTION
I've rewritten your GROK pattern to be compatible to the OPNsense 19.7 Suricata [syslog output](https://docs.opnsense.org/manual/logging.html#remote-syslog).

Sample input:
```
hostname suricata[90751]: [wDrop] [1:2010144:6] ET P2P Vuze BT UDP Connection (5) [Classification: Potential Corporate Privacy Violation] [Priority: 1] {UDP} 1.1.1.1:27032 -> 2.2.2.2:27029
```